### PR TITLE
Add express-rate-limit dependency for request rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "express-rate-limit": "^7.5.1",
     "i18next": "^23.11.5",
     "jquery": "^3.6.1",
     "lucide-react": "^0.513.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6406,6 +6406,11 @@ expect@^29.0.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
+express-rate-limit@^7.5.1:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-7.5.1.tgz#8c3a42f69209a3a1c969890070ece9e20a879dec"
+  integrity sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==
+
 express@^4.17.3:
   version "4.21.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.21.2.tgz#cf250e48362174ead6cea4a566abef0162c1ec32"


### PR DESCRIPTION
- Included express-rate-limit version 7.5.1 in package.json and updated yarn.lock.
- This addition supports the implementation of rate limiting features in the application.